### PR TITLE
fix: backend=threading is required for images in memory

### DIFF
--- a/book/3-processing.md
+++ b/book/3-processing.md
@@ -178,7 +178,7 @@ Alternatively `joblib` has a builtin class, `joblib.Parallel`, to automatically 
 The `n_jobs` parameter controls the maximum number of concurrently running jobs.
 Commonly you'll either want to set `n_jobs=-1` to use all available CPUs, or set it to a custom number to limit the memory usage of multiple jobs running at the same time.
 
-[^joblib-backend]: Because of the way this textbook is built, we've had to manually specify `backend='threading'`. You shouldn't have to specify the `backend` parameter when running code yourself - for more info see the [`joblib.Parallel` documentation](https://joblib.readthedocs.io/en/stable/generated/joblib.Parallel.html#joblib-parallel).
+[^joblib-backend]: Because we are working with an image in memory, we've had to manually specify `backend='threading'`. When working with images on disk, you shouldn't have to specify the `backend` parameter - for more info see the [`joblib.Parallel` documentation](https://joblib.readthedocs.io/en/stable/generated/joblib.Parallel.html#joblib-parallel).
 
 ```{code-cell} ipython3
 jobs = [


### PR DESCRIPTION
I was not able to get the example to work without specifying `backend=threading` in `executor = joblib.Parallel(n_jobs=2, backend=threading)`. If I do not specify this, I get a completely black image for the output (all pixel values 0). Consulting Claude, it suggested this is because the default `joblib` backend, `loky`, uses multiprocessing, so each worker runs as a separate process in its own memory space. When working with an image in memory, each worker is writing to its own memory space, and not back to one shared location, as would be the case for an image on disk.

I tested this by changing some of the code to create the store on disk for `clipped_image`, and this worked with `executor = joblib.Parallel(n_jobs=2)`.

I suggested an edit to the footnote to clarify this.